### PR TITLE
Add eprints2bags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ display a plot of data hosted in the CaltechDATA repository. Demo at [plots.calt
     + _epfmt_, a tool for formatting validating/pretty printing/converting EPrint metadata to/from XML and JSON
     + _doi2eprintxml_, a command line tool that queries CrossRef and DataCite APIs for metadata returning EPrints XML output
     + _eprintxml2json_, a command line tool that transform EPrints 3.x EPrint XML to JSON
-+ [eprints2bags](https://github.com/caltechlibrary/eprints2bags), a Python program for downloading records from an EPrints server and creating [BagIt](https://en.wikipedia.org/wiki/BagIt)-style packages out of them
++ [eprints2bags](https://github.com/caltechlibrary/eprints2bags), is a Python program for downloading records from an EPrints server and creating [BagIt](https://en.wikipedia.org/wiki/BagIt)-style packages out of them
 + [orcidtools](https://caltechlibrary.github.io/orcidtools), is a Go package and provides _orcid_, an ORCID harvesting tool, for v2.0 of the [ORCID API](https://orcid.org/organizations/integrators/API)
 + [crossrefapi](https://caltechlibrary.github.io/crossrefapi), is a Go package for working politely with the public [CrossRef API](https://api.crossref.org). A command line tool returning JSON is also included in this repository.
 + [dataciteapi](https://caltechlibrary.github.io/dataciteapi), is a Go package for working with the public [DataCite API](https://api.datacite.org). A command line tool returning JSON is also included in this repository.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ display a plot of data hosted in the CaltechDATA repository. Demo at [plots.calt
     + _epfmt_, a tool for formatting validating/pretty printing/converting EPrint metadata to/from XML and JSON
     + _doi2eprintxml_, a command line tool that queries CrossRef and DataCite APIs for metadata returning EPrints XML output
     + _eprintxml2json_, a command line tool that transform EPrints 3.x EPrint XML to JSON
++ [eprints2bags](https://github.com/caltechlibrary/eprints2bags), a Python program for downloading records from an EPrints server and creating [BagIt](https://en.wikipedia.org/wiki/BagIt)-style packages out of them
 + [orcidtools](https://caltechlibrary.github.io/orcidtools), is a Go package and provides _orcid_, an ORCID harvesting tool, for v2.0 of the [ORCID API](https://orcid.org/organizations/integrators/API)
 + [crossrefapi](https://caltechlibrary.github.io/crossrefapi), is a Go package for working politely with the public [CrossRef API](https://api.crossref.org). A command line tool returning JSON is also included in this repository.
 + [dataciteapi](https://caltechlibrary.github.io/dataciteapi), is a Go package for working with the public [DataCite API](https://api.datacite.org). A command line tool returning JSON is also included in this repository.

--- a/index.html
+++ b/index.html
@@ -56,6 +56,7 @@ display a plot of data hosted in the CaltechDATA repository. Demo at <a href="pl
 <li><em>doi2eprintxml</em>, a command line tool that queries CrossRef and DataCite APIs for metadata returning EPrints XML output</li>
 <li><em>eprintxml2json</em>, a command line tool that transform EPrints 3.x EPrint XML to JSON</li>
 </ul></li>
+<li><a href="https://github.com/caltechlibrary/eprints2bags">eprints2bags</a>, a Python program for downloading records from an EPrints server and creating <a target="_blank" href="https://en.wikipedia.org/wiki/BagIt">BagIt</a> packages out of them
 <li><a href="https://caltechlibrary.github.io/orcidtools">orcidtools</a>, is a Go package and provides <em>orcid</em>, an ORCID harvesting tool, for v2.0 of the <a href="https://orcid.org/organizations/integrators/API">ORCID API</a></li>
 <li><a href="https://caltechlibrary.github.io/crossrefapi">crossrefapi</a>, is a Go package for working politely with the public <a href="https://api.crossref.org">CrossRef API</a>. A command line tool returning JSON is also included in this repository.</li>
 <li><a href="https://caltechlibrary.github.io/dataciteapi">dataciteapi</a>, is a Go package for working with the public <a href="https://api.datacite.org">DataCite API</a>. A command line tool returning JSON is also included in this repository.</li>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@ display a plot of data hosted in the CaltechDATA repository. Demo at <a href="pl
 <li><em>doi2eprintxml</em>, a command line tool that queries CrossRef and DataCite APIs for metadata returning EPrints XML output</li>
 <li><em>eprintxml2json</em>, a command line tool that transform EPrints 3.x EPrint XML to JSON</li>
 </ul></li>
-<li><a href="https://github.com/caltechlibrary/eprints2bags">eprints2bags</a>, a Python program for downloading records from an EPrints server and creating <a target="_blank" href="https://en.wikipedia.org/wiki/BagIt">BagIt</a> packages out of them
+<li><a href="https://github.com/caltechlibrary/eprints2bags">eprints2bags</a>, is a Python program for downloading records from an EPrints server and creating <a target="_blank" href="https://en.wikipedia.org/wiki/BagIt">BagIt</a> packages out of them
 <li><a href="https://caltechlibrary.github.io/orcidtools">orcidtools</a>, is a Go package and provides <em>orcid</em>, an ORCID harvesting tool, for v2.0 of the <a href="https://orcid.org/organizations/integrators/API">ORCID API</a></li>
 <li><a href="https://caltechlibrary.github.io/crossrefapi">crossrefapi</a>, is a Go package for working politely with the public <a href="https://api.crossref.org">CrossRef API</a>. A command line tool returning JSON is also included in this repository.</li>
 <li><a href="https://caltechlibrary.github.io/dataciteapi">dataciteapi</a>, is a Go package for working with the public <a href="https://api.datacite.org">DataCite API</a>. A command line tool returning JSON is also included in this repository.</li>


### PR DESCRIPTION
This adds eprints2bags to the list of software tools, under the section on harvesters and systems integration.